### PR TITLE
[codex] Remove Reddit WSB ingestion

### DIFF
--- a/codex/config/settings.yaml
+++ b/codex/config/settings.yaml
@@ -5,6 +5,8 @@ pipeline:
   cache_dir: "data/raw"
   log_level: "INFO"
   start_date: "2020-01-01"
+  request_timeout_seconds: 30
+  use_stub_fallback: true
 
 price_volume:
   adjusted: true
@@ -25,13 +27,11 @@ catalysts:
 wsb:
   sources:
     - apewisdom
-    - praw
     - kaggle
   rolling_window_days: 20
   apewisdom_top_n: 50
   sentiment_model: "finbert"
   fallback_sentiment_model: "vader"
-  subreddit: "wallstreetbets"
   kaggle_dataset_path: "data/raw/kaggle/wsb_historical.csv"
 
 options_flow:
@@ -109,10 +109,6 @@ providers:
     enabled: true
   apewisdom:
     base_url: "https://apewisdom.io/api/v1.0"
-  reddit:
-    client_id: ""
-    client_secret: ""
-    user_agent: "catalyst-crowding-research"
   finra:
     base_url: "https://api.finra.org"
 

--- a/codex/src/pipeline/wsb_data.py
+++ b/codex/src/pipeline/wsb_data.py
@@ -1,4 +1,4 @@
-"""WSB / Reddit mention ingestion with ApeWisdom, PRAW, and Kaggle paths."""
+"""WSB mention ingestion with ApeWisdom and historical dataset paths."""
 
 from __future__ import annotations
 
@@ -10,11 +10,10 @@ from pathlib import Path
 from typing import Iterable, Protocol
 
 import pandas as pd
-import requests
 
 from src.utils.config import AppSettings, load_settings
 from src.utils.db import DatabaseManager
-from src.utils.http import HttpRequestError, JsonHttpClient
+from src.utils.http import JsonHttpClient
 from src.utils.timestamps import ensure_utc_timestamp
 
 LOGGER = logging.getLogger(__name__)
@@ -33,23 +32,9 @@ class ApeWisdomMention:
     as_of_timestamp: datetime
 
 
-@dataclass
-class RedditMessage:
-    created_at: datetime
-    ticker: str
-    text: str
-    score: float
-    as_of_timestamp: datetime
-
-
 class ApeWisdomClient(Protocol):
     def get_daily_top_mentions(self, trade_date: date, top_n: int) -> Iterable[ApeWisdomMention]:
         """Return daily top-mentioned tickers from ApeWisdom."""
-
-
-class RedditMessageClient(Protocol):
-    def get_messages(self, start_date: date, end_date: date, subreddit: str) -> Iterable[RedditMessage]:
-        """Return WSB posts/comments with timestamps and message text."""
 
 
 class StubApeWisdomClient:
@@ -77,37 +62,6 @@ class StubApeWisdomClient:
                 as_of_timestamp=base_timestamp,
             ),
         ]
-
-
-class StubRedditMessageClient:
-    def get_messages(self, start_date: date, end_date: date, subreddit: str) -> Iterable[RedditMessage]:
-        del subreddit
-        current = start_date
-        while current <= end_date:
-            if current.weekday() < 5:
-                ts = datetime.combine(current, time(hour=22, minute=0), tzinfo=timezone.utc)
-                yield RedditMessage(
-                    created_at=ts,
-                    ticker="ABCD",
-                    text="ABCD looks bullish, huge beat, strong breakout and squeeze setup",
-                    score=float(250 + current.day * 3),
-                    as_of_timestamp=ts + timedelta(minutes=5),
-                )
-                yield RedditMessage(
-                    created_at=ts + timedelta(minutes=10),
-                    ticker="ABCD",
-                    text="ABCD still bullish and ripping",
-                    score=float(180 + current.day * 2),
-                    as_of_timestamp=ts + timedelta(minutes=15),
-                )
-                yield RedditMessage(
-                    created_at=ts + timedelta(minutes=20),
-                    ticker="EFGH",
-                    text="EFGH looks weak and bearish after dilution",
-                    score=float(90 + current.day),
-                    as_of_timestamp=ts + timedelta(minutes=25),
-                )
-            current += timedelta(days=1)
 
 
 class RealApeWisdomClient:
@@ -153,110 +107,6 @@ class RealApeWisdomClient:
             return float(value)
         except (TypeError, ValueError):
             return None
-
-
-class RedditOauthClient:
-    SEARCH_LIMIT = 100
-
-    def __init__(self, settings: AppSettings) -> None:
-        credentials = settings.providers.reddit
-        if not credentials.client_id or not credentials.client_secret:
-            raise ValueError("Reddit client_id/client_secret are required for the live Reddit client")
-        self.settings = settings
-        self.credentials = credentials
-        self.cache_dir = settings.pipeline.cache_dir
-        self.timeout_seconds = settings.pipeline.request_timeout_seconds
-        self._token: str | None = None
-        self._session = requests.Session()
-        self._session.headers.update({"User-Agent": credentials.user_agent})
-
-    def get_messages(self, start_date: date, end_date: date, subreddit: str) -> Iterable[RedditMessage]:
-        trade_dates = self._trading_dates(start_date, end_date)
-        if not trade_dates:
-            return []
-
-        token = self._get_token()
-        session = requests.Session()
-        session.headers.update(
-            {
-                "Authorization": f"Bearer {token}",
-                "User-Agent": self.credentials.user_agent,
-            }
-        )
-
-        messages: list[RedditMessage] = []
-        for trade_date in trade_dates:
-            query = f"timestamp:{int(datetime.combine(trade_date, time.min, tzinfo=timezone.utc).timestamp())}..{int(datetime.combine(trade_date, time.max, tzinfo=timezone.utc).timestamp())}"
-            try:
-                response = session.get(
-                    f"https://oauth.reddit.com/r/{subreddit}/search.json",
-                    params={
-                        "q": query,
-                        "restrict_sr": "on",
-                        "sort": "new",
-                        "syntax": "cloudsearch",
-                        "limit": self.SEARCH_LIMIT,
-                        "t": "all",
-                    },
-                    timeout=self.timeout_seconds,
-                )
-                response.raise_for_status()
-            except requests.RequestException as exc:
-                LOGGER.warning("Reddit search failed for %s on %s: %s", subreddit, trade_date, exc)
-                continue
-
-            payload = response.json()
-            children = payload.get("data", {}).get("children", [])
-            for child in children:
-                post_data = child.get("data", {})
-                created_ts = post_data.get("created_utc")
-                body = post_data.get("selftext") or post_data.get("title") or ""
-                created_at = None if created_ts is None else datetime.fromtimestamp(float(created_ts), tz=timezone.utc)
-                if created_at is None or created_at.date() != trade_date:
-                    continue
-                ticker = WsbDataLoader._extract_primary_ticker(str(body))
-                if ticker is None:
-                    continue
-                messages.append(
-                    RedditMessage(
-                        created_at=created_at,
-                        ticker=ticker,
-                        text=str(body),
-                        score=float(post_data.get("score") or 0.0),
-                        as_of_timestamp=created_at + timedelta(minutes=1),
-                    )
-                )
-        return messages
-
-    def _get_token(self) -> str:
-        if self._token is not None:
-            return self._token
-        try:
-            response = self._session.post(
-                "https://www.reddit.com/api/v1/access_token",
-                auth=(self.credentials.client_id, self.credentials.client_secret),
-                data={"grant_type": "client_credentials"},
-                timeout=self.timeout_seconds,
-            )
-            response.raise_for_status()
-        except requests.RequestException as exc:
-            raise RuntimeError(f"Unable to authenticate with Reddit: {exc}") from exc
-        payload = response.json()
-        token = payload.get("access_token")
-        if not token:
-            raise RuntimeError("Reddit authentication returned no access token")
-        self._token = str(token)
-        return self._token
-
-    @staticmethod
-    def _trading_dates(start_date: date, end_date: date) -> list[date]:
-        dates: list[date] = []
-        current = start_date
-        while current <= end_date:
-            if current.weekday() < 5:
-                dates.append(current)
-            current += timedelta(days=1)
-        return dates
 
 
 class SimpleSentimentAnalyzer:
@@ -322,13 +172,11 @@ class WsbDataLoader:
         settings: AppSettings,
         db: DatabaseManager,
         apewisdom_client: ApeWisdomClient | None = None,
-        reddit_client: RedditMessageClient | None = None,
         sentiment_analyzer: SimpleSentimentAnalyzer | None = None,
     ) -> None:
         self.settings = settings
         self.db = db
         self.apewisdom_client = apewisdom_client or self._default_apewisdom_client(settings)
-        self.reddit_client = reddit_client or self._default_reddit_client(settings)
         self.sentiment_analyzer = sentiment_analyzer or SimpleSentimentAnalyzer(
             preferred_model=settings.wsb.sentiment_model,
             fallback_model=settings.wsb.fallback_sentiment_model,
@@ -363,49 +211,6 @@ class WsbDataLoader:
         normalized = self._compute_rollups(pd.DataFrame(rows), source="apewisdom")
         self.db.upsert_wsb_mentions(normalized)
         LOGGER.info("Stored ApeWisdom rows=%s", len(normalized))
-        return len(normalized)
-
-    def load_praw_range(self, start_date: date, end_date: date) -> int:
-        messages = list(self.reddit_client.get_messages(start_date, end_date, self.settings.wsb.subreddit))
-        if not messages:
-            return 0
-
-        rows: list[dict[str, object]] = []
-        grouped: dict[tuple[date, str], list[RedditMessage]] = {}
-        for message in messages:
-            ensure_utc_timestamp(message.created_at, label=f"{message.ticker}.created_at")
-            ensure_utc_timestamp(message.as_of_timestamp, label=f"{message.ticker}.as_of_timestamp")
-            grouped.setdefault((message.created_at.date(), message.ticker), []).append(message)
-
-        for (trade_date, ticker), bucket in grouped.items():
-            scores = [self.sentiment_analyzer.score(message.text) for message in bucket]
-            dominant_count = sum(1 for score in scores if self._label(score) == self._dominant_label(scores))
-            total_labeled = sum(1 for score in scores if self._label(score) != "neutral")
-            sentiment_unanimity = None if total_labeled == 0 else dominant_count / total_labeled
-            average_score = None if not scores else float(sum(scores) / len(scores))
-            upvotes = float(sum(message.score for message in bucket))
-            as_of_timestamp = max(message.as_of_timestamp for message in bucket)
-            rows.append(
-                {
-                    "date": trade_date.isoformat(),
-                    "ticker": ticker,
-                    "mention_count": float(len(bucket)),
-                    "mention_count_prior_day": None,
-                    "mention_velocity_pct": None,
-                    "mention_vs_baseline": None,
-                    "sentiment_score": average_score,
-                    "sentiment_unanimity": sentiment_unanimity,
-                    "upvotes": upvotes,
-                    "rank": None,
-                    "rank_change_24h": None,
-                    "as_of_timestamp": as_of_timestamp.isoformat(),
-                    "source": "praw",
-                }
-            )
-
-        normalized = self._compute_rollups(pd.DataFrame(rows), source="praw")
-        self.db.upsert_wsb_mentions(normalized)
-        LOGGER.info("Stored PRAW rows=%s", len(normalized))
         return len(normalized)
 
     def load_kaggle_history(self, dataset_path: Path | None = None) -> int:
@@ -515,22 +320,6 @@ class WsbDataLoader:
             return StubApeWisdomClient()
 
     @staticmethod
-    def _default_reddit_client(settings: AppSettings) -> RedditMessageClient:
-        credentials = settings.providers.reddit
-        if credentials.client_id and credentials.client_secret:
-            try:
-                return RedditOauthClient(settings)
-            except Exception as exc:
-                if not settings.pipeline.use_stub_fallback:
-                    raise
-                LOGGER.warning("Falling back to stub Reddit client: %s", exc)
-        elif not settings.pipeline.use_stub_fallback:
-            raise ValueError("Reddit credentials are required when stub fallback is disabled")
-        else:
-            LOGGER.warning("Reddit credentials not configured; falling back to stub Reddit client")
-        return StubRedditMessageClient()
-
-    @staticmethod
     def _dominant_label(scores: list[float]) -> str:
         labels = [WsbDataLoader._label(score) for score in scores if WsbDataLoader._label(score) != "neutral"]
         if not labels:
@@ -571,8 +360,6 @@ def load_wsb_from_config(
     total = 0
     if "apewisdom" in settings.wsb.sources:
         total += loader.load_apewisdom_range(start_date, end_date)
-    if "praw" in settings.wsb.sources:
-        total += loader.load_praw_range(start_date, end_date)
     if "kaggle" in settings.wsb.sources:
         total += loader.load_kaggle_history()
     return total

--- a/codex/src/utils/config.py
+++ b/codex/src/utils/config.py
@@ -1,0 +1,251 @@
+"""Application config and compliance blocklist loaders."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, Field, model_validator
+
+
+class DatabaseSettings(BaseModel):
+    path: Path
+
+
+class PipelineSettings(BaseModel):
+    cache_dir: Path
+    log_level: str = "INFO"
+    start_date: str = "2020-01-01"
+    request_timeout_seconds: int = 30
+    use_stub_fallback: bool = True
+
+
+class PriceVolumeSettings(BaseModel):
+    adjusted: bool = True
+    include_premarket: bool = True
+    rolling_window_days: int = 20
+    chunk_size: int = 250
+
+
+class CatalystSettings(BaseModel):
+    sources: list[str] = Field(default_factory=lambda: ["finnhub", "yahoo_finance"])
+    include_earnings: bool = True
+    include_analyst_actions: bool = True
+    include_fda_events: bool = True
+    include_company_news: bool = True
+    chunk_size: int = 250
+
+
+class WsbSettings(BaseModel):
+    sources: list[str] = Field(default_factory=lambda: ["apewisdom", "kaggle"])
+    rolling_window_days: int = 20
+    apewisdom_top_n: int = 50
+    sentiment_model: str = "finbert"
+    fallback_sentiment_model: str = "vader"
+    kaggle_dataset_path: Path = Path("data/raw/kaggle/wsb_historical.csv")
+
+
+class OptionsFlowSettings(BaseModel):
+    adjusted: bool = True
+    rolling_window_days: int = 20
+    use_trade_level_small_lot_estimate: bool = True
+
+
+class ShortInterestSettings(BaseModel):
+    report_publication_lag_business_days: int = 8
+    use_latest_available_as_of_date: bool = True
+
+
+class AttentionSignalSettings(BaseModel):
+    medium_threshold: float = 0.4
+    high_threshold: float = 0.7
+    mention_velocity_cap: float = 3.0
+    mention_vs_baseline_cap: float = 5.0
+    unusual_options_volume_cap: float = 4.0
+    wsb_weight: float = 0.75
+    options_weight: float = 0.25
+
+
+class PositioningSignalSettings(BaseModel):
+    medium_threshold: float = 0.4
+    high_threshold: float = 0.7
+    small_lot_call_put_ratio_cap: float = 4.0
+    unusual_options_volume_cap: float = 4.0
+    short_pct_float_cap: float = 0.35
+    days_to_cover_cap: float = 12.0
+
+
+class TrapRiskSignalSettings(BaseModel):
+    present_threshold: float = 0.65
+    round_number_band_pct: float = 0.02
+    yearly_extreme_band_pct: float = 0.03
+    support_resistance_band_pct: float = 0.025
+    round_numbers: list[float] = Field(default_factory=lambda: [10.0, 20.0, 50.0, 100.0])
+
+
+class PremarketSignalSettings(BaseModel):
+    meaningful_gap_pct: float = 0.04
+    min_relative_volume: float = 1.0
+    min_dollar_volume: float = 500_000.0
+    max_spread_estimate_pct: float = 0.03
+
+
+class SqueezeRiskSignalSettings(BaseModel):
+    block_threshold: float = 0.7
+    short_pct_float_cap: float = 0.35
+    days_to_cover_cap: float = 12.0
+    low_float_cap: float = 25_000_000.0
+    upward_attention_cap: float = 1.0
+    gap_magnitude_cap: float = 0.2
+
+
+class ScannerSignalSettings(BaseModel):
+    continuation_score_threshold: float = 0.62
+    mean_reversion_score_threshold: float = 0.52
+
+
+class SignalSettings(BaseModel):
+    attention: AttentionSignalSettings = Field(default_factory=AttentionSignalSettings)
+    positioning: PositioningSignalSettings = Field(default_factory=PositioningSignalSettings)
+    trap_risk: TrapRiskSignalSettings = Field(default_factory=TrapRiskSignalSettings)
+    premarket: PremarketSignalSettings = Field(default_factory=PremarketSignalSettings)
+    squeeze_risk: SqueezeRiskSignalSettings = Field(default_factory=SqueezeRiskSignalSettings)
+    scanner: ScannerSignalSettings = Field(default_factory=ScannerSignalSettings)
+
+
+class UniverseSettings(BaseModel):
+    min_market_cap: float
+    max_market_cap: float
+    min_price: float
+    min_avg_volume_20d: float
+    allowed_exchanges: list[str]
+    include_delisted: bool = True
+
+    @model_validator(mode="after")
+    def validate_bounds(self) -> "UniverseSettings":
+        if self.min_market_cap >= self.max_market_cap:
+            raise ValueError("min_market_cap must be smaller than max_market_cap")
+        return self
+
+
+class PolygonSettings(BaseModel):
+    api_key: str = ""
+    base_url: str = "https://api.polygon.io"
+
+
+class SchwabSettings(BaseModel):
+    app_key: str = ""
+    app_secret: str = ""
+
+
+class FinnhubSettings(BaseModel):
+    api_key: str = ""
+    base_url: str = "https://finnhub.io/api/v1"
+
+
+class YahooFinanceSettings(BaseModel):
+    enabled: bool = True
+
+
+class ApeWisdomSettings(BaseModel):
+    base_url: str = "https://apewisdom.io/api/v1.0"
+
+
+class FinraSettings(BaseModel):
+    base_url: str = "https://api.finra.org"
+
+
+class ProviderSettings(BaseModel):
+    polygon: PolygonSettings = Field(default_factory=PolygonSettings)
+    schwab: SchwabSettings = Field(default_factory=SchwabSettings)
+    finnhub: FinnhubSettings = Field(default_factory=FinnhubSettings)
+    yahoo_finance: YahooFinanceSettings = Field(default_factory=YahooFinanceSettings)
+    apewisdom: ApeWisdomSettings = Field(default_factory=ApeWisdomSettings)
+    finra: FinraSettings = Field(default_factory=FinraSettings)
+
+
+class ComplianceSettings(BaseModel):
+    blocklist_path: Path
+    fail_on_blocklist_conflicts: bool = True
+
+
+class BlocklistEntry(BaseModel):
+    value: str
+    reason: str
+
+
+class ComplianceBlocklist(BaseModel):
+    blocked_tickers: set[str] = Field(default_factory=set)
+    blocked_sectors: set[str] = Field(default_factory=set)
+    blocked_industries: set[str] = Field(default_factory=set)
+
+
+class AppSettings(BaseModel):
+    database: DatabaseSettings
+    pipeline: PipelineSettings
+    price_volume: PriceVolumeSettings = Field(default_factory=PriceVolumeSettings)
+    catalysts: CatalystSettings = Field(default_factory=CatalystSettings)
+    wsb: WsbSettings = Field(default_factory=WsbSettings)
+    options_flow: OptionsFlowSettings = Field(default_factory=OptionsFlowSettings)
+    short_interest: ShortInterestSettings = Field(default_factory=ShortInterestSettings)
+    signals: SignalSettings = Field(default_factory=SignalSettings)
+    universe: UniverseSettings
+    providers: ProviderSettings = Field(default_factory=ProviderSettings)
+    compliance: ComplianceSettings
+    compliance_blocklist: ComplianceBlocklist = Field(default_factory=ComplianceBlocklist)
+
+
+def _read_yaml(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        loaded = yaml.safe_load(handle) or {}
+    if not isinstance(loaded, dict):
+        raise ValueError(f"Expected a mapping in {path}")
+    return loaded
+
+
+def load_blocklist(path: Path) -> ComplianceBlocklist:
+    payload = _read_yaml(path)
+
+    blocked_tickers = {
+        str(item["ticker"]).upper()
+        for item in payload.get("tickers", [])
+        if isinstance(item, dict) and item.get("ticker")
+    }
+    blocked_sectors = {
+        str(item["sector"])
+        for item in payload.get("sectors", [])
+        if isinstance(item, dict) and item.get("sector")
+    }
+    blocked_industries = {
+        str(item["industry"])
+        for item in payload.get("industries", [])
+        if isinstance(item, dict) and item.get("industry")
+    }
+    return ComplianceBlocklist(
+        blocked_tickers=blocked_tickers,
+        blocked_sectors=blocked_sectors,
+        blocked_industries=blocked_industries,
+    )
+
+
+def load_settings(path: Path) -> AppSettings:
+    raw = _read_yaml(path)
+    base_dir = path.parent.parent
+
+    database_path = base_dir / raw["database"]["path"]
+    cache_dir = base_dir / raw["pipeline"]["cache_dir"]
+    blocklist_path = base_dir / raw["compliance"]["blocklist_path"]
+    wsb_dataset_path = base_dir / raw.get("wsb", {}).get("kaggle_dataset_path", "data/raw/kaggle/wsb_historical.csv")
+
+    settings = AppSettings.model_validate(
+        {
+            **raw,
+            "database": {**raw["database"], "path": database_path},
+            "pipeline": {**raw["pipeline"], "cache_dir": cache_dir},
+            "wsb": {**raw.get("wsb", {}), "kaggle_dataset_path": wsb_dataset_path},
+            "compliance": {**raw["compliance"], "blocklist_path": blocklist_path},
+        }
+    )
+    settings.compliance_blocklist = load_blocklist(settings.compliance.blocklist_path)
+    return settings

--- a/codex/tests/test_wsb_data.py
+++ b/codex/tests/test_wsb_data.py
@@ -1,7 +1,7 @@
 from datetime import date
 from pathlib import Path
 
-from src.pipeline.wsb_data import WsbDataLoader
+from src.pipeline.wsb_data import StubApeWisdomClient, WsbDataLoader
 from src.utils.config import load_settings
 from src.utils.db import DatabaseManager
 
@@ -14,7 +14,7 @@ def test_apewisdom_rollups_compute_velocity_and_baseline(tmp_path: Path) -> None
     db = DatabaseManager(db_path)
     db.initialize()
 
-    loader = WsbDataLoader(settings=settings, db=db)
+    loader = WsbDataLoader(settings=settings, db=db, apewisdom_client=StubApeWisdomClient())
     inserted = loader.load_apewisdom_range(date(2024, 1, 1), date(2024, 2, 15))
 
     assert inserted > 0
@@ -36,34 +36,3 @@ def test_apewisdom_rollups_compute_velocity_and_baseline(tmp_path: Path) -> None
     assert row["mention_vs_baseline"] is not None
     assert row["upvotes"] is not None
     assert row["rank"] is not None
-
-
-def test_praw_rollups_store_sentiment_and_unanimity(tmp_path: Path) -> None:
-    settings = load_settings(Path("config/settings.yaml"))
-    db_path = tmp_path / "praw.sqlite"
-    settings.database.path = db_path
-    settings.wsb.sources = ["praw"]
-    db = DatabaseManager(db_path)
-    db.initialize()
-
-    loader = WsbDataLoader(settings=settings, db=db)
-    inserted = loader.load_praw_range(date(2024, 1, 1), date(2024, 1, 31))
-
-    assert inserted > 0
-
-    with db.connect() as connection:
-        row = connection.execute(
-            """
-            SELECT mention_count, sentiment_score, sentiment_unanimity, upvotes
-            FROM wsb_mentions
-            WHERE ticker = 'ABCD' AND source = 'praw'
-            ORDER BY date DESC
-            LIMIT 1
-            """
-        ).fetchone()
-
-    assert row is not None
-    assert row["mention_count"] is not None
-    assert row["sentiment_score"] is not None
-    assert row["sentiment_unanimity"] is not None
-    assert row["upvotes"] is not None


### PR DESCRIPTION
## What changed
- removed Reddit/PRAW as a supported WSB ingestion path
- kept WSB sourcing focused on ApeWisdom and Kaggle history
- removed Reddit credentials and subreddit config from settings
- added the missing pipeline timeout and stub-fallback settings consumed by live/stub provider loaders
- made the WSB test deterministic by injecting the built-in ApeWisdom stub client

## Why
Reddit API access is no longer a reliable foundation for this workflow, and the repo should not imply direct Reddit ingestion is part of the supported historical/research pipeline.

This also fixes a config/schema mismatch surfaced while validating the change: several loaders already expected `pipeline.request_timeout_seconds` and `pipeline.use_stub_fallback`, but those settings were missing from the checked-in config.

## Impact
- users no longer need Reddit credentials for the WSB pipeline
- the WSB loader only runs ApeWisdom and Kaggle paths
- local validation is more reliable because the remaining WSB test does not depend on live network access

## Validation
- `PYTHONPATH=. .venv/bin/pytest tests/test_wsb_data.py`